### PR TITLE
Fixed mandatory[missing][field] bug

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,7 @@
       - 2
       - "1tbs"
     callback-return: 2
-    camelcase: 0
+    camelcase: 2
     comma-dangle:
       - 2
       - "never"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,7 @@
       - 2
       - "1tbs"
     callback-return: 2
-    camelcase: 2
+    camelcase: 0
     comma-dangle:
       - 2
       - "never"

--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+# v2.1.2 - 01.29.2018
+
+* Fixed bug in QueryBuilder where `mandatory[missing]` filter was not working because of ElasticSearch `v5` update
+
 # v2.1.1 - 10.30.2017
 
 * Fixed bug where `filtered` query is replaced by `bool` query in ElasticSearch `v5` and higher

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -330,7 +330,7 @@ module.exports = function (matchFields, diagnosticsFilterKey, self) {
 				}
 
 				if (filter.missing) {
-					queryBool.must_not = (queryBool.must_not || []).concat(filter.missing);
+					queryBool['must_not'] = (queryBool['must_not'] || []).concat(filter.missing);
 
 					return;
 				}

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -225,9 +225,9 @@ module.exports = function (matchFields, diagnosticsFilterKey, self) {
 			filterSet.missing.forEach((field) => {
 				missingFilter = {
 					missing : {
-						existence : true,
-						field : field,
-						'null_value' : true
+						exists : {
+							field : field
+						}
 					}
 				};
 
@@ -325,6 +325,12 @@ module.exports = function (matchFields, diagnosticsFilterKey, self) {
 			buildFilters(filters.mandatory).forEach((filter) => {
 				if (filter.match) {
 					queryBool.must = (queryBool.must || []).concat(filter);
+
+					return;
+				}
+
+				if (filter.missing) {
+					queryBool.must_not = (queryBool.must_not || []).concat(filter.missing);
 
 					return;
 				}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reindeer",
   "description": "Provides schema enforcement based on Elasticsearch type mappings",
   "main": "./lib/index.js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "Joshua Thomas (https://github.com/brozeph)",
   "contributors": [
     "Robin Momii (https://github.com/rmomii)"

--- a/test/lib/builder.js
+++ b/test/lib/builder.js
@@ -195,6 +195,36 @@ describe('builder', function () {
 			query.query.bool.must.should.be.a('array');
 		});
 
+		it('should build mandatory missing queries for fields', function () {
+			var query = builder.buildQuery({
+				'filters' : {
+					'mandatory' : {
+						'missing' : 'test'
+					}
+				}
+			});
+
+			should.exist(query.query);
+			should.exist(query.query.bool);
+			should.exist(query.query.bool.must_not);
+			query.query.bool.must_not.should.be.a('array');
+		});
+
+		it('should build mandatory missing queries for fields', function () {
+			var query = builder.buildQuery({
+				'filters' : {
+					'mandatory' : {
+						'missing' : 'test,test1,test2'
+					}
+				}
+			});
+
+			should.exist(query.query);
+			should.exist(query.query.bool);
+			should.exist(query.query.bool.must_not);
+			query.query.bool.must_not.should.be.a('array');
+		});
+
 		it('should build optional contains queries', function () {
 			var query = builder.buildQuery({
 				'filters' : {


### PR DESCRIPTION
filters[mandatory][missing]=field now returns results where the field is either null or missing